### PR TITLE
[bug fix] remove jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+package-lock.json
 .idea
 .DS_Store
 *.suo

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -88,12 +88,11 @@
               <a-descriptions-item label="页数">{{ record.pages }}</a-descriptions-item>
               <a-descriptions-item label="语言">{{ record.language }}</a-descriptions-item>
               <a-descriptions-item label="发布年份">{{ record.year }}</a-descriptions-item>
-            </a-descriptions>
+              </a-descriptions>
             </a-row>
             <a-row style="margin-top: 10px;">
               <a-space>
                 <a-button v-for="item in ipfsGateways" :key="item" @click="downloadFromIPFS(item, record)">{{ item }}</a-button>
-                <a-button @click="downloadFromIPFS('127.0.0.1:8080', record, 'http')">127.0.0.1:8080</a-button>
               </a-space>
             </a-row>
           </a-card>


### PR DESCRIPTION
There is an unnecessary button on the list of download tab
Should we remove it ?
<img width="880" alt="image" src="https://user-images.githubusercontent.com/34466246/204562741-882af9d9-4656-44b6-bdff-64ed0da3510c.png">
