### PR TITLE
fix: webui footer position

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,6 @@
+#app {
+  height: 100%;
+}
+.ant-layout.layout {
+  min-height: 100%;
+}


### PR DESCRIPTION
I notice the footer is in wrong position.
 
before:
<img width="1712" alt="截屏2022-11-30 00 01 28" src="https://user-images.githubusercontent.com/46164858/204579954-3a88d20a-c30d-45b4-b1b5-913a40e4d03c.png">
after:
<img width="1085" alt="截屏2022-11-30 00 01 57" src="https://user-images.githubusercontent.com/46164858/204580223-ec35849e-dbbd-4272-a04e-c8929580325e.png">

